### PR TITLE
feat: allow providing extension IDs with slashes

### DIFF
--- a/js/src/common/WidgetManager.ts
+++ b/js/src/common/WidgetManager.ts
@@ -51,7 +51,7 @@ export default class WidgetManager {
         // remove this in a future version and use extension value directly.
         const extension = widget.extension || widget.id!.split(':')[0];
 
-        return extension in flarum.extensions;
+        return extension.replace(/\//g,'-') in flarum.extensions;
       })
       .map((widget: Widget) => ({ ...widget, extension: widget.extension || widget.id!.split(':')[0], state: this.states[widget.id!] }));
 


### PR DESCRIPTION
Core now uses `/` as a separator between vendor and package name in frontend initializers. I think it would be good to build in basic support for them here, too.

I spent quite a while trying to work out why my widget wasn't showing in the list, and it turned out to be because of this.